### PR TITLE
"프로젝트에 자동 추가" workflow 생성

### DIFF
--- a/.github/workflows/org_project_automation.yml
+++ b/.github/workflows/org_project_automation.yml
@@ -1,0 +1,22 @@
+name: Auto Add to Org Project
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add_to_project:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Add to Organization Project
+        uses: actions/add-to-project@v1
+        with:
+          project-url: https://github.com/orgs/uitiorg/projects/2
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          item-id: ${{ github.event.issue.node_id || github.event.pull_request.node_id }}

--- a/.github/workflows/org_project_automation.yml
+++ b/.github/workflows/org_project_automation.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Add to Organization Project
-        uses: actions/add-to-project@v1
+        uses: actions/add-to-project@vlatest
         with:
           project-url: https://github.com/orgs/uitiorg/projects/2
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/org_project_automation.yml
+++ b/.github/workflows/org_project_automation.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Add to Organization Project
-        uses: actions/add-to-project@vlatest
+        uses: actions/add-to-project@latest
         with:
           project-url: https://github.com/orgs/uitiorg/projects/2
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### 작업 내용
GitHub Organization 프로젝트를 활용하여 특정 주제와 연관된 작업들의 진행 상황을 효율적으로 관리하기 위해, 이슈와 PR 생성 시 이를 자동으로 프로젝트에 등록하고 상태를 업데이트하도록 설정합니다.

### 관련 이슈
Closes #1

### 작업 내용

#### 자동 등록:
- 새 이슈 또는 PR이 생성되면 지정된 Organization 프로젝트에 자동으로 등록됩니다.
- 초기 상태는 TODO로 설정됩니다.

#### 상태 업데이트:
- 이슈 또는 PR이 닫히면 상태가 자동으로 DONE으로 변경됩니다.